### PR TITLE
Fix link 

### DIFF
--- a/adoc/release_notes.adoc
+++ b/adoc/release_notes.adoc
@@ -39,7 +39,7 @@ No breaking changes in this release.
 
 *Security Updates:*
 
-* Updated {harbor} 2.13.2 to 2.14.1 (link:https://github.com/goharbor/harbor/compare/v2.14.0...v2.14.1[Release Notes 2.14.1])
+* Updated {harbor} 2.13.2 to 2.14.1 (link:https://github.com/goharbor/harbor/releases/tag/v2.14.1[Release Notes v2.14.1])
 
 *Container Image Updates:*
 


### PR DESCRIPTION
Small change in the link release notes of Harbor:

<img width="909" height="708" alt="image" src="https://github.com/user-attachments/assets/5b50918a-c1e7-417e-918d-4b3016a7833e" />

Could you check the render correctly because now it's messy:
<img width="1173" height="310" alt="image" src="https://github.com/user-attachments/assets/69f61df9-a81e-46ce-a841-35a1078df699" />
